### PR TITLE
Storing advanced settings and some clean-up

### DIFF
--- a/BorderlessMinecraft/Configuration/Config.cs
+++ b/BorderlessMinecraft/Configuration/Config.cs
@@ -16,18 +16,21 @@ namespace BorderlessMinecraft.Configuration
         {
             Registry = new RegistryEditor(@"SOFTWARE\BorderlessMinecraft"); //open the registry in this location
 
-            if (bool.TryParse((string)Registry.GetKeyValue(nameof(StartOnBoot)), out bool value1))
-                _startOnBoot = value1;
-            if (bool.TryParse((string)Registry.GetKeyValue(nameof(StartMinimized)), out bool value2))
-                _startMinimized = value2;
-            if (bool.TryParse((string)Registry.GetKeyValue(nameof(MinimizeToTray)), out bool value3))
-                _minimizeToTray = value3;
-            if (bool.TryParse((string)Registry.GetKeyValue(nameof(AutomaticBorderless)), out bool value4))
-                _automaticBorderless = value4;
-            if (bool.TryParse((string)Registry.GetKeyValue(nameof(PreserveTaskBar)), out bool value5))
-                _preserveTaskBar = value5;
-            if (bool.TryParse((string)Registry.GetKeyValue(nameof(ShowAllClients)), out bool value6))
-                _showAllClients = value6;
+            if (bool.TryParse((string)Registry.GetKeyValue(nameof(StartOnBoot)), out bool startOnBoot))
+                _startOnBoot = startOnBoot;
+            if (bool.TryParse((string)Registry.GetKeyValue(nameof(StartMinimized)), out bool startMinimized))
+                _startMinimized = startMinimized;
+            if (bool.TryParse((string)Registry.GetKeyValue(nameof(MinimizeToTray)), out bool minimizeToTray))
+                _minimizeToTray = minimizeToTray;
+            if (bool.TryParse((string)Registry.GetKeyValue(nameof(AutomaticBorderless)), out bool automaticBorderless))
+                _automaticBorderless = automaticBorderless;
+            if (bool.TryParse((string)Registry.GetKeyValue(nameof(PreserveTaskBar)), out bool preserveTaskBar))
+                _preserveTaskBar = preserveTaskBar;
+            if (bool.TryParse((string)Registry.GetKeyValue(nameof(ShowAllClients)), out bool showAllClients))
+                _showAllClients = showAllClients;
+            if (bool.TryParse((string)Registry.GetKeyValue(nameof(Advanced)), out bool advanced))
+                _advanced = advanced;
+            _advancedParams = "" + (string)Registry.GetKeyValue(nameof(AdvancedParams));
         }
 
         public bool StartOnBoot
@@ -88,5 +91,23 @@ namespace BorderlessMinecraft.Configuration
             }
         }
         private bool _showAllClients;
+        public bool Advanced
+        {
+            get => _advanced; set
+            {
+                _advanced = value;
+                Registry.SetKeyValue(nameof(Advanced), value);
+            }
+        }
+        private bool _advanced;
+        public string AdvancedParams
+        {
+            get => _advancedParams; set
+            {
+                _advancedParams = value;
+                Registry.SetKeyValue(nameof(AdvancedParams), value);
+            }
+        }
+        private string _advancedParams;
     }
 }

--- a/BorderlessMinecraft/Form1.Designer.cs
+++ b/BorderlessMinecraft/Form1.Designer.cs
@@ -69,7 +69,7 @@ namespace BorderlessMinecraft
             this.TrayIcon = new System.Windows.Forms.NotifyIcon(this.components);
             this.ToolTipContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.Exit = new System.Windows.Forms.ToolStripMenuItem();
-            this.ContextMenuSettings = new System.Windows.Forms.ToolStripMenuItem();
+            this.ContextMenuShow = new System.Windows.Forms.ToolStripMenuItem();
             this.SettingsMenu = new System.Windows.Forms.MenuStrip();
             this.Settings = new System.Windows.Forms.ToolStripMenuItem();
             this.startOnBootMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -281,10 +281,10 @@ namespace BorderlessMinecraft
             // ToolTipContextMenu
             // 
             this.ToolTipContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.Exit,
-            this.ContextMenuSettings});
+            this.ContextMenuShow,
+            this.Exit});
             this.ToolTipContextMenu.Name = "ToolTipContextMenu";
-            this.ToolTipContextMenu.Size = new System.Drawing.Size(117, 48);
+            this.ToolTipContextMenu.Size = new System.Drawing.Size(215, 48);
             // 
             // Exit
             // 
@@ -294,12 +294,13 @@ namespace BorderlessMinecraft
             this.Exit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.Exit.Click += new System.EventHandler(this.Exit_Click);
             // 
-            // ContextMenuSettings
+            // ContextMenuShow
             // 
-            this.ContextMenuSettings.Name = "ContextMenuSettings";
-            this.ContextMenuSettings.Size = new System.Drawing.Size(116, 22);
-            this.ContextMenuSettings.Text = "Settings";
-            this.ContextMenuSettings.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.ContextMenuShow.Name = "ContextMenuShow";
+            this.ContextMenuShow.Size = new System.Drawing.Size(214, 22);
+            this.ContextMenuShow.Text = "Show Borderless Minecraft";
+            this.ContextMenuShow.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.ContextMenuShow.Click += new System.EventHandler(this.ContextMenuShow_Click);
             // 
             // SettingsMenu
             // 
@@ -449,7 +450,7 @@ namespace BorderlessMinecraft
         private System.Windows.Forms.ToolStripMenuItem startMinimizedMenuItem;
         private System.Windows.Forms.ToolStripMenuItem minimizeToTrayMenuItem;
         private System.Windows.Forms.ToolStripMenuItem automaticBorderlessMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem ContextMenuSettings;
+        private System.Windows.Forms.ToolStripMenuItem ContextMenuShow;
         private System.Windows.Forms.ToolStripMenuItem preserveTaskbarMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showAllClientsMenuItem;
     }

--- a/BorderlessMinecraft/Form1.Designer.cs
+++ b/BorderlessMinecraft/Form1.Designer.cs
@@ -17,7 +17,7 @@
 
 namespace BorderlessMinecraft
 {
-    partial class Form1
+    partial class MainForm
     {
         /// <summary>
         /// Required designer variable.
@@ -46,39 +46,39 @@ namespace BorderlessMinecraft
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Form1));
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
             this.debugInstructionsLabel = new System.Windows.Forms.Label();
-            this.button1 = new System.Windows.Forms.Button();
-            this.listBox1 = new System.Windows.Forms.ListBox();
-            this.button2 = new System.Windows.Forms.Button();
-            this.button3 = new System.Windows.Forms.Button();
-            this.pictureBox1 = new System.Windows.Forms.PictureBox();
-            this.checkBox1 = new System.Windows.Forms.CheckBox();
-            this.textBox1 = new System.Windows.Forms.TextBox();
-            this.label1 = new System.Windows.Forms.Label();
-            this.label2 = new System.Windows.Forms.Label();
-            this.label3 = new System.Windows.Forms.Label();
-            this.label4 = new System.Windows.Forms.Label();
-            this.textBox2 = new System.Windows.Forms.TextBox();
-            this.textBox3 = new System.Windows.Forms.TextBox();
-            this.textBox4 = new System.Windows.Forms.TextBox();
-            this.label5 = new System.Windows.Forms.Label();
-            this.textBox5 = new System.Windows.Forms.TextBox();
-            this.linkLabel1 = new System.Windows.Forms.LinkLabel();
-            this.button4 = new System.Windows.Forms.Button();
+            this.goBorderlessButton = new System.Windows.Forms.Button();
+            this.processesListBox = new System.Windows.Forms.ListBox();
+            this.refreshButton = new System.Windows.Forms.Button();
+            this.setTitleButton = new System.Windows.Forms.Button();
+            this.mainTitlePictureBox = new System.Windows.Forms.PictureBox();
+            this.advancedCheckBox = new System.Windows.Forms.CheckBox();
+            this.xPosTextBox = new System.Windows.Forms.TextBox();
+            this.xPosLabel = new System.Windows.Forms.Label();
+            this.yPosLabel = new System.Windows.Forms.Label();
+            this.widthLabel = new System.Windows.Forms.Label();
+            this.heightLabel = new System.Windows.Forms.Label();
+            this.yPosTextBox = new System.Windows.Forms.TextBox();
+            this.widthTextBox = new System.Windows.Forms.TextBox();
+            this.heightTextBox = new System.Windows.Forms.TextBox();
+            this.newTitleLabel = new System.Windows.Forms.Label();
+            this.newTitleTextBox = new System.Windows.Forms.TextBox();
+            this.helpLinkLabel = new System.Windows.Forms.LinkLabel();
+            this.restoreWindowButton = new System.Windows.Forms.Button();
             this.TrayIcon = new System.Windows.Forms.NotifyIcon(this.components);
             this.ToolTipContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.Exit = new System.Windows.Forms.ToolStripMenuItem();
             this.ContextMenuSettings = new System.Windows.Forms.ToolStripMenuItem();
             this.SettingsMenu = new System.Windows.Forms.MenuStrip();
             this.Settings = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem5 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem6 = new System.Windows.Forms.ToolStripMenuItem();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            this.startOnBootMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.startMinimizedMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.minimizeToTrayMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.automaticBorderlessMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.preserveTaskbarMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.showAllClientsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            ((System.ComponentModel.ISupportInitialize)(this.mainTitlePictureBox)).BeginInit();
             this.ToolTipContextMenu.SuspendLayout();
             this.SettingsMenu.SuspendLayout();
             this.SuspendLayout();
@@ -93,177 +93,176 @@ namespace BorderlessMinecraft
             this.debugInstructionsLabel.TabIndex = 1;
             this.debugInstructionsLabel.Text = "Select the session of Minecraft you want to make borderless and click \'Go Borderl" +
     "ess\'";
-            this.debugInstructionsLabel.Click += new System.EventHandler(this.debugInstructionsLabel_Click);
             // 
-            // button1
+            // goBorderlessButton
             // 
-            this.button1.Location = new System.Drawing.Point(378, 209);
-            this.button1.Margin = new System.Windows.Forms.Padding(2);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(97, 28);
-            this.button1.TabIndex = 2;
-            this.button1.Text = "Go Borderless!";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
+            this.goBorderlessButton.Location = new System.Drawing.Point(378, 209);
+            this.goBorderlessButton.Margin = new System.Windows.Forms.Padding(2);
+            this.goBorderlessButton.Name = "goBorderlessButton";
+            this.goBorderlessButton.Size = new System.Drawing.Size(97, 28);
+            this.goBorderlessButton.TabIndex = 2;
+            this.goBorderlessButton.Text = "Go Borderless!";
+            this.goBorderlessButton.UseVisualStyleBackColor = true;
+            this.goBorderlessButton.Click += new System.EventHandler(this.goBorderlessButton_Click);
             // 
-            // listBox1
+            // processesListBox
             // 
-            this.listBox1.FormattingEnabled = true;
-            this.listBox1.Location = new System.Drawing.Point(69, 117);
-            this.listBox1.Name = "listBox1";
-            this.listBox1.Size = new System.Drawing.Size(304, 121);
-            this.listBox1.TabIndex = 4;
-            this.listBox1.SelectedIndexChanged += new System.EventHandler(this.listBox1_SelectedIndexChanged_1);
+            this.processesListBox.FormattingEnabled = true;
+            this.processesListBox.Location = new System.Drawing.Point(69, 117);
+            this.processesListBox.Name = "processesListBox";
+            this.processesListBox.Size = new System.Drawing.Size(304, 121);
+            this.processesListBox.TabIndex = 4;
+            this.processesListBox.SelectedIndexChanged += new System.EventHandler(this.processesListBox_SelectedIndexChanged);
             // 
-            // button2
+            // refreshButton
             // 
-            this.button2.Location = new System.Drawing.Point(378, 117);
-            this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(97, 28);
-            this.button2.TabIndex = 5;
-            this.button2.Text = "Refresh List";
-            this.button2.UseVisualStyleBackColor = true;
-            this.button2.Click += new System.EventHandler(this.button2_Click);
+            this.refreshButton.Location = new System.Drawing.Point(378, 117);
+            this.refreshButton.Name = "refreshButton";
+            this.refreshButton.Size = new System.Drawing.Size(97, 28);
+            this.refreshButton.TabIndex = 5;
+            this.refreshButton.Text = "Refresh List";
+            this.refreshButton.UseVisualStyleBackColor = true;
+            this.refreshButton.Click += new System.EventHandler(this.refreshButton_Click);
             // 
-            // button3
+            // setTitleButton
             // 
-            this.button3.Location = new System.Drawing.Point(378, 147);
-            this.button3.Name = "button3";
-            this.button3.Size = new System.Drawing.Size(97, 29);
-            this.button3.TabIndex = 6;
-            this.button3.Text = "Set Title";
-            this.button3.UseVisualStyleBackColor = true;
-            this.button3.Click += new System.EventHandler(this.button3_Click);
+            this.setTitleButton.Location = new System.Drawing.Point(378, 147);
+            this.setTitleButton.Name = "setTitleButton";
+            this.setTitleButton.Size = new System.Drawing.Size(97, 29);
+            this.setTitleButton.TabIndex = 6;
+            this.setTitleButton.Text = "Set Title";
+            this.setTitleButton.UseVisualStyleBackColor = true;
+            this.setTitleButton.Click += new System.EventHandler(this.setTitleButton_Click);
             // 
-            // pictureBox1
+            // mainTitlePictureBox
             // 
-            this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
-            this.pictureBox1.Location = new System.Drawing.Point(23, 27);
-            this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.Size = new System.Drawing.Size(496, 50);
-            this.pictureBox1.TabIndex = 7;
-            this.pictureBox1.TabStop = false;
+            this.mainTitlePictureBox.Image = ((System.Drawing.Image)(resources.GetObject("mainTitlePictureBox.Image")));
+            this.mainTitlePictureBox.Location = new System.Drawing.Point(23, 27);
+            this.mainTitlePictureBox.Name = "mainTitlePictureBox";
+            this.mainTitlePictureBox.Size = new System.Drawing.Size(496, 50);
+            this.mainTitlePictureBox.TabIndex = 7;
+            this.mainTitlePictureBox.TabStop = false;
             // 
-            // checkBox1
+            // advancedCheckBox
             // 
-            this.checkBox1.AutoSize = true;
-            this.checkBox1.Location = new System.Drawing.Point(19, 278);
-            this.checkBox1.Name = "checkBox1";
-            this.checkBox1.Size = new System.Drawing.Size(75, 17);
-            this.checkBox1.TabIndex = 8;
-            this.checkBox1.Text = "Advanced";
-            this.checkBox1.UseVisualStyleBackColor = true;
-            this.checkBox1.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged);
+            this.advancedCheckBox.AutoSize = true;
+            this.advancedCheckBox.Location = new System.Drawing.Point(19, 278);
+            this.advancedCheckBox.Name = "advancedCheckBox";
+            this.advancedCheckBox.Size = new System.Drawing.Size(75, 17);
+            this.advancedCheckBox.TabIndex = 8;
+            this.advancedCheckBox.Text = "Advanced";
+            this.advancedCheckBox.UseVisualStyleBackColor = true;
+            this.advancedCheckBox.CheckedChanged += new System.EventHandler(this.advancedCheckBox_CheckedChanged);
             // 
-            // textBox1
+            // xPosTextBox
             // 
-            this.textBox1.Location = new System.Drawing.Point(130, 295);
-            this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(70, 20);
-            this.textBox1.TabIndex = 9;
-            this.textBox1.Visible = false;
+            this.xPosTextBox.Location = new System.Drawing.Point(130, 295);
+            this.xPosTextBox.Name = "xPosTextBox";
+            this.xPosTextBox.Size = new System.Drawing.Size(70, 20);
+            this.xPosTextBox.TabIndex = 9;
+            this.xPosTextBox.Visible = false;
             // 
-            // label1
+            // xPosLabel
             // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(130, 279);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(54, 13);
-            this.label1.TabIndex = 10;
-            this.label1.Text = "X Position";
-            this.label1.Visible = false;
-            this.label1.Click += new System.EventHandler(this.label1_Click);
+            this.xPosLabel.AutoSize = true;
+            this.xPosLabel.Location = new System.Drawing.Point(130, 279);
+            this.xPosLabel.Name = "xPosLabel";
+            this.xPosLabel.Size = new System.Drawing.Size(54, 13);
+            this.xPosLabel.TabIndex = 10;
+            this.xPosLabel.Text = "X Position";
+            this.xPosLabel.Visible = false;
+            this.xPosLabel.Click += new System.EventHandler(this.xPosLabel_Click);
             // 
-            // label2
+            // yPosLabel
             // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(203, 279);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(54, 13);
-            this.label2.TabIndex = 11;
-            this.label2.Text = "Y Position";
-            this.label2.Visible = false;
+            this.yPosLabel.AutoSize = true;
+            this.yPosLabel.Location = new System.Drawing.Point(203, 279);
+            this.yPosLabel.Name = "yPosLabel";
+            this.yPosLabel.Size = new System.Drawing.Size(54, 13);
+            this.yPosLabel.TabIndex = 11;
+            this.yPosLabel.Text = "Y Position";
+            this.yPosLabel.Visible = false;
             // 
-            // label3
+            // widthLabel
             // 
-            this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(279, 279);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(37, 13);
-            this.label3.TabIndex = 12;
-            this.label3.Text = "X Size";
-            this.label3.Visible = false;
+            this.widthLabel.AutoSize = true;
+            this.widthLabel.Location = new System.Drawing.Point(279, 279);
+            this.widthLabel.Name = "widthLabel";
+            this.widthLabel.Size = new System.Drawing.Size(37, 13);
+            this.widthLabel.TabIndex = 12;
+            this.widthLabel.Text = "X Size";
+            this.widthLabel.Visible = false;
             // 
-            // label4
+            // heightLabel
             // 
-            this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(355, 279);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(37, 13);
-            this.label4.TabIndex = 13;
-            this.label4.Text = "Y Size";
-            this.label4.Visible = false;
+            this.heightLabel.AutoSize = true;
+            this.heightLabel.Location = new System.Drawing.Point(355, 279);
+            this.heightLabel.Name = "heightLabel";
+            this.heightLabel.Size = new System.Drawing.Size(37, 13);
+            this.heightLabel.TabIndex = 13;
+            this.heightLabel.Text = "Y Size";
+            this.heightLabel.Visible = false;
             // 
-            // textBox2
+            // yPosTextBox
             // 
-            this.textBox2.Location = new System.Drawing.Point(206, 295);
-            this.textBox2.Name = "textBox2";
-            this.textBox2.Size = new System.Drawing.Size(70, 20);
-            this.textBox2.TabIndex = 14;
-            this.textBox2.Visible = false;
+            this.yPosTextBox.Location = new System.Drawing.Point(206, 295);
+            this.yPosTextBox.Name = "yPosTextBox";
+            this.yPosTextBox.Size = new System.Drawing.Size(70, 20);
+            this.yPosTextBox.TabIndex = 14;
+            this.yPosTextBox.Visible = false;
             // 
-            // textBox3
+            // widthTextBox
             // 
-            this.textBox3.Location = new System.Drawing.Point(282, 295);
-            this.textBox3.Name = "textBox3";
-            this.textBox3.Size = new System.Drawing.Size(70, 20);
-            this.textBox3.TabIndex = 15;
-            this.textBox3.Visible = false;
+            this.widthTextBox.Location = new System.Drawing.Point(282, 295);
+            this.widthTextBox.Name = "widthTextBox";
+            this.widthTextBox.Size = new System.Drawing.Size(70, 20);
+            this.widthTextBox.TabIndex = 15;
+            this.widthTextBox.Visible = false;
             // 
-            // textBox4
+            // heightTextBox
             // 
-            this.textBox4.Location = new System.Drawing.Point(358, 295);
-            this.textBox4.Name = "textBox4";
-            this.textBox4.Size = new System.Drawing.Size(70, 20);
-            this.textBox4.TabIndex = 16;
-            this.textBox4.Visible = false;
+            this.heightTextBox.Location = new System.Drawing.Point(358, 295);
+            this.heightTextBox.Name = "heightTextBox";
+            this.heightTextBox.Size = new System.Drawing.Size(70, 20);
+            this.heightTextBox.TabIndex = 16;
+            this.heightTextBox.Visible = false;
             // 
-            // label5
+            // newTitleLabel
             // 
-            this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(69, 245);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(103, 13);
-            this.label5.TabIndex = 17;
-            this.label5.Text = "New Title (Optional):";
+            this.newTitleLabel.AutoSize = true;
+            this.newTitleLabel.Location = new System.Drawing.Point(69, 245);
+            this.newTitleLabel.Name = "newTitleLabel";
+            this.newTitleLabel.Size = new System.Drawing.Size(103, 13);
+            this.newTitleLabel.TabIndex = 17;
+            this.newTitleLabel.Text = "New Title (Optional):";
             // 
-            // textBox5
+            // newTitleTextBox
             // 
-            this.textBox5.Location = new System.Drawing.Point(178, 242);
-            this.textBox5.Name = "textBox5";
-            this.textBox5.Size = new System.Drawing.Size(195, 20);
-            this.textBox5.TabIndex = 18;
+            this.newTitleTextBox.Location = new System.Drawing.Point(178, 242);
+            this.newTitleTextBox.Name = "newTitleTextBox";
+            this.newTitleTextBox.Size = new System.Drawing.Size(195, 20);
+            this.newTitleTextBox.TabIndex = 18;
             // 
-            // linkLabel1
+            // helpLinkLabel
             // 
-            this.linkLabel1.AutoSize = true;
-            this.linkLabel1.Location = new System.Drawing.Point(490, 282);
-            this.linkLabel1.Name = "linkLabel1";
-            this.linkLabel1.Size = new System.Drawing.Size(29, 13);
-            this.linkLabel1.TabIndex = 19;
-            this.linkLabel1.TabStop = true;
-            this.linkLabel1.Text = "Help";
-            this.linkLabel1.Visible = false;
+            this.helpLinkLabel.AutoSize = true;
+            this.helpLinkLabel.Location = new System.Drawing.Point(490, 282);
+            this.helpLinkLabel.Name = "helpLinkLabel";
+            this.helpLinkLabel.Size = new System.Drawing.Size(29, 13);
+            this.helpLinkLabel.TabIndex = 19;
+            this.helpLinkLabel.TabStop = true;
+            this.helpLinkLabel.Text = "Help";
+            this.helpLinkLabel.Visible = false;
             // 
-            // button4
+            // restoreWindowButton
             // 
-            this.button4.Location = new System.Drawing.Point(378, 178);
-            this.button4.Name = "button4";
-            this.button4.Size = new System.Drawing.Size(97, 29);
-            this.button4.TabIndex = 20;
-            this.button4.Text = "Restore Window";
-            this.button4.UseVisualStyleBackColor = true;
-            this.button4.Click += new System.EventHandler(this.button4_Click);
+            this.restoreWindowButton.Location = new System.Drawing.Point(378, 178);
+            this.restoreWindowButton.Name = "restoreWindowButton";
+            this.restoreWindowButton.Size = new System.Drawing.Size(97, 29);
+            this.restoreWindowButton.TabIndex = 20;
+            this.restoreWindowButton.Text = "Restore Window";
+            this.restoreWindowButton.UseVisualStyleBackColor = true;
+            this.restoreWindowButton.Click += new System.EventHandler(this.restoreWindowButton_Click);
             // 
             // TrayIcon
             // 
@@ -309,93 +308,93 @@ namespace BorderlessMinecraft
             this.Settings.Checked = true;
             this.Settings.CheckState = System.Windows.Forms.CheckState.Checked;
             this.Settings.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripMenuItem1,
-            this.toolStripMenuItem2,
-            this.toolStripMenuItem3,
-            this.toolStripMenuItem4,
-            this.toolStripMenuItem5,
-            this.toolStripMenuItem6});
+            this.startOnBootMenuItem,
+            this.startMinimizedMenuItem,
+            this.minimizeToTrayMenuItem,
+            this.automaticBorderlessMenuItem,
+            this.preserveTaskbarMenuItem,
+            this.showAllClientsMenuItem});
             this.Settings.Name = "Settings";
             this.Settings.Size = new System.Drawing.Size(61, 20);
             this.Settings.Text = "Settings";
             // 
-            // toolStripMenuItem1
+            // startOnBootMenuItem
             // 
-            this.toolStripMenuItem1.CheckOnClick = true;
-            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(187, 22);
-            this.toolStripMenuItem1.Text = "Start on Boot";
+            this.startOnBootMenuItem.CheckOnClick = true;
+            this.startOnBootMenuItem.Name = "startOnBootMenuItem";
+            this.startOnBootMenuItem.Size = new System.Drawing.Size(187, 22);
+            this.startOnBootMenuItem.Text = "Start on Boot";
             // 
-            // toolStripMenuItem2
+            // startMinimizedMenuItem
             // 
-            this.toolStripMenuItem2.CheckOnClick = true;
-            this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-            this.toolStripMenuItem2.Size = new System.Drawing.Size(187, 22);
-            this.toolStripMenuItem2.Text = "Start Minimized";
+            this.startMinimizedMenuItem.CheckOnClick = true;
+            this.startMinimizedMenuItem.Name = "startMinimizedMenuItem";
+            this.startMinimizedMenuItem.Size = new System.Drawing.Size(187, 22);
+            this.startMinimizedMenuItem.Text = "Start Minimized";
             // 
-            // toolStripMenuItem3
+            // minimizeToTrayMenuItem
             // 
-            this.toolStripMenuItem3.CheckOnClick = true;
-            this.toolStripMenuItem3.Name = "toolStripMenuItem3";
-            this.toolStripMenuItem3.Size = new System.Drawing.Size(187, 22);
-            this.toolStripMenuItem3.Text = "Minimize to Tray";
+            this.minimizeToTrayMenuItem.CheckOnClick = true;
+            this.minimizeToTrayMenuItem.Name = "minimizeToTrayMenuItem";
+            this.minimizeToTrayMenuItem.Size = new System.Drawing.Size(187, 22);
+            this.minimizeToTrayMenuItem.Text = "Minimize to Tray";
             // 
-            // toolStripMenuItem4
+            // automaticBorderlessMenuItem
             // 
-            this.toolStripMenuItem4.CheckOnClick = true;
-            this.toolStripMenuItem4.Name = "toolStripMenuItem4";
-            this.toolStripMenuItem4.Size = new System.Drawing.Size(187, 22);
-            this.toolStripMenuItem4.Text = "Automatic Borderless";
-            this.toolStripMenuItem4.ToolTipText = "Requires administrator privleges";
+            this.automaticBorderlessMenuItem.CheckOnClick = true;
+            this.automaticBorderlessMenuItem.Name = "automaticBorderlessMenuItem";
+            this.automaticBorderlessMenuItem.Size = new System.Drawing.Size(187, 22);
+            this.automaticBorderlessMenuItem.Text = "Automatic Borderless";
+            this.automaticBorderlessMenuItem.ToolTipText = "Requires administrator privleges";
             // 
-            // toolStripMenuItem5
+            // preserveTaskbarMenuItem
             // 
-            this.toolStripMenuItem5.CheckOnClick = true;
-            this.toolStripMenuItem5.Name = "toolStripMenuItem5";
-            this.toolStripMenuItem5.Size = new System.Drawing.Size(187, 22);
-            this.toolStripMenuItem5.Text = "Preserve Taskbar";
-            this.toolStripMenuItem5.ToolTipText = "The taskbar will be visible below Minecraft";
+            this.preserveTaskbarMenuItem.CheckOnClick = true;
+            this.preserveTaskbarMenuItem.Name = "preserveTaskbarMenuItem";
+            this.preserveTaskbarMenuItem.Size = new System.Drawing.Size(187, 22);
+            this.preserveTaskbarMenuItem.Text = "Preserve Taskbar";
+            this.preserveTaskbarMenuItem.ToolTipText = "The taskbar will be visible below Minecraft";
             // 
-            // toolStripMenuItem6
+            // showAllClientsMenuItem
             // 
-            this.toolStripMenuItem6.CheckOnClick = true;
-            this.toolStripMenuItem6.Name = "toolStripMenuItem6";
-            this.toolStripMenuItem6.Size = new System.Drawing.Size(187, 22);
-            this.toolStripMenuItem6.Text = "Show All Clients";
-            this.toolStripMenuItem6.ToolTipText = "Shows non-vanilla MC clients, but may show other Java applications as well";
+            this.showAllClientsMenuItem.CheckOnClick = true;
+            this.showAllClientsMenuItem.Name = "showAllClientsMenuItem";
+            this.showAllClientsMenuItem.Size = new System.Drawing.Size(187, 22);
+            this.showAllClientsMenuItem.Text = "Show All Clients";
+            this.showAllClientsMenuItem.ToolTipText = "Shows non-vanilla MC clients, but may show other Java applications as well";
             // 
-            // Form1
+            // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(543, 322);
             this.Controls.Add(this.SettingsMenu);
-            this.Controls.Add(this.button4);
-            this.Controls.Add(this.linkLabel1);
-            this.Controls.Add(this.textBox5);
-            this.Controls.Add(this.label5);
-            this.Controls.Add(this.textBox4);
-            this.Controls.Add(this.textBox3);
-            this.Controls.Add(this.textBox2);
-            this.Controls.Add(this.label4);
-            this.Controls.Add(this.label3);
-            this.Controls.Add(this.label2);
-            this.Controls.Add(this.label1);
-            this.Controls.Add(this.textBox1);
-            this.Controls.Add(this.checkBox1);
-            this.Controls.Add(this.pictureBox1);
-            this.Controls.Add(this.button3);
-            this.Controls.Add(this.button2);
-            this.Controls.Add(this.listBox1);
-            this.Controls.Add(this.button1);
+            this.Controls.Add(this.restoreWindowButton);
+            this.Controls.Add(this.helpLinkLabel);
+            this.Controls.Add(this.newTitleTextBox);
+            this.Controls.Add(this.newTitleLabel);
+            this.Controls.Add(this.heightTextBox);
+            this.Controls.Add(this.widthTextBox);
+            this.Controls.Add(this.yPosTextBox);
+            this.Controls.Add(this.heightLabel);
+            this.Controls.Add(this.widthLabel);
+            this.Controls.Add(this.yPosLabel);
+            this.Controls.Add(this.xPosLabel);
+            this.Controls.Add(this.xPosTextBox);
+            this.Controls.Add(this.advancedCheckBox);
+            this.Controls.Add(this.mainTitlePictureBox);
+            this.Controls.Add(this.setTitleButton);
+            this.Controls.Add(this.refreshButton);
+            this.Controls.Add(this.processesListBox);
+            this.Controls.Add(this.goBorderlessButton);
             this.Controls.Add(this.debugInstructionsLabel);
             this.ForeColor = System.Drawing.SystemColors.ControlText;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.SettingsMenu;
             this.Margin = new System.Windows.Forms.Padding(2);
-            this.Name = "Form1";
+            this.Name = "MainForm";
             this.Text = "Borderless Minecraft 1.3.0";
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.mainTitlePictureBox)).EndInit();
             this.ToolTipContextMenu.ResumeLayout(false);
             this.SettingsMenu.ResumeLayout(false);
             this.SettingsMenu.PerformLayout();
@@ -406,36 +405,36 @@ namespace BorderlessMinecraft
 
         #endregion
         private System.Windows.Forms.Label debugInstructionsLabel;
-        private System.Windows.Forms.Button button1;
-        private System.Windows.Forms.ListBox listBox1;
-        private System.Windows.Forms.Button button2;
-        private System.Windows.Forms.Button button3;
-        private System.Windows.Forms.PictureBox pictureBox1;
-        private System.Windows.Forms.CheckBox checkBox1;
-        private System.Windows.Forms.TextBox textBox1;
-        private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.Label label3;
-        private System.Windows.Forms.Label label4;
-        private System.Windows.Forms.TextBox textBox2;
-        private System.Windows.Forms.TextBox textBox3;
-        private System.Windows.Forms.TextBox textBox4;
-        private System.Windows.Forms.Label label5;
-        private System.Windows.Forms.TextBox textBox5;
-        private System.Windows.Forms.LinkLabel linkLabel1;
-        private System.Windows.Forms.Button button4;
+        private System.Windows.Forms.Button goBorderlessButton;
+        private System.Windows.Forms.ListBox processesListBox;
+        private System.Windows.Forms.Button refreshButton;
+        private System.Windows.Forms.Button setTitleButton;
+        private System.Windows.Forms.PictureBox mainTitlePictureBox;
+        private System.Windows.Forms.CheckBox advancedCheckBox;
+        private System.Windows.Forms.TextBox xPosTextBox;
+        private System.Windows.Forms.Label xPosLabel;
+        private System.Windows.Forms.Label yPosLabel;
+        private System.Windows.Forms.Label widthLabel;
+        private System.Windows.Forms.Label heightLabel;
+        private System.Windows.Forms.TextBox yPosTextBox;
+        private System.Windows.Forms.TextBox widthTextBox;
+        private System.Windows.Forms.TextBox heightTextBox;
+        private System.Windows.Forms.Label newTitleLabel;
+        private System.Windows.Forms.TextBox newTitleTextBox;
+        private System.Windows.Forms.LinkLabel helpLinkLabel;
+        private System.Windows.Forms.Button restoreWindowButton;
         private System.Windows.Forms.NotifyIcon TrayIcon;
         private System.Windows.Forms.ContextMenuStrip ToolTipContextMenu;
         private System.Windows.Forms.ToolStripMenuItem Exit;
         private System.Windows.Forms.MenuStrip SettingsMenu;
         private System.Windows.Forms.ToolStripMenuItem Settings;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem1;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem2;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem3;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem4;
+        private System.Windows.Forms.ToolStripMenuItem startOnBootMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem startMinimizedMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem minimizeToTrayMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem automaticBorderlessMenuItem;
         private System.Windows.Forms.ToolStripMenuItem ContextMenuSettings;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem5;
-        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem6;
+        private System.Windows.Forms.ToolStripMenuItem preserveTaskbarMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem showAllClientsMenuItem;
     }
 }
 

--- a/BorderlessMinecraft/Form1.Designer.cs
+++ b/BorderlessMinecraft/Form1.Designer.cs
@@ -401,7 +401,7 @@ namespace BorderlessMinecraft
             this.MainMenuStrip = this.SettingsMenu;
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "MainForm";
-            this.Text = "Borderless Minecraft 1.3.0";
+            this.Text = "Borderless Minecraft <version>";
             ((System.ComponentModel.ISupportInitialize)(this.mainTitlePictureBox)).EndInit();
             this.ToolTipContextMenu.ResumeLayout(false);
             this.SettingsMenu.ResumeLayout(false);

--- a/BorderlessMinecraft/Form1.Designer.cs
+++ b/BorderlessMinecraft/Form1.Designer.cs
@@ -161,6 +161,8 @@ namespace BorderlessMinecraft
             this.xPosTextBox.Size = new System.Drawing.Size(70, 20);
             this.xPosTextBox.TabIndex = 9;
             this.xPosTextBox.Visible = false;
+            this.xPosTextBox.Validating += new System.ComponentModel.CancelEventHandler(this.AdvancedParamsTextBox_Validating);
+            this.xPosTextBox.Validated += new System.EventHandler(this.AdvancedParamsTextBox_Validated);
             // 
             // xPosLabel
             // 
@@ -171,7 +173,6 @@ namespace BorderlessMinecraft
             this.xPosLabel.TabIndex = 10;
             this.xPosLabel.Text = "X Position";
             this.xPosLabel.Visible = false;
-            this.xPosLabel.Click += new System.EventHandler(this.xPosLabel_Click);
             // 
             // yPosLabel
             // 
@@ -210,6 +211,8 @@ namespace BorderlessMinecraft
             this.yPosTextBox.Size = new System.Drawing.Size(70, 20);
             this.yPosTextBox.TabIndex = 14;
             this.yPosTextBox.Visible = false;
+            this.yPosTextBox.Validating += new System.ComponentModel.CancelEventHandler(this.AdvancedParamsTextBox_Validating);
+            this.yPosTextBox.Validated += new System.EventHandler(this.AdvancedParamsTextBox_Validated);
             // 
             // widthTextBox
             // 
@@ -218,6 +221,8 @@ namespace BorderlessMinecraft
             this.widthTextBox.Size = new System.Drawing.Size(70, 20);
             this.widthTextBox.TabIndex = 15;
             this.widthTextBox.Visible = false;
+            this.widthTextBox.Validating += new System.ComponentModel.CancelEventHandler(this.AdvancedParamsTextBox_Validating);
+            this.widthTextBox.Validated += new System.EventHandler(this.AdvancedParamsTextBox_Validated);
             // 
             // heightTextBox
             // 
@@ -226,6 +231,8 @@ namespace BorderlessMinecraft
             this.heightTextBox.Size = new System.Drawing.Size(70, 20);
             this.heightTextBox.TabIndex = 16;
             this.heightTextBox.Visible = false;
+            this.heightTextBox.Validating += new System.ComponentModel.CancelEventHandler(this.AdvancedParamsTextBox_Validating);
+            this.heightTextBox.Validated += new System.EventHandler(this.AdvancedParamsTextBox_Validated);
             // 
             // newTitleLabel
             // 
@@ -367,6 +374,7 @@ namespace BorderlessMinecraft
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoValidate = System.Windows.Forms.AutoValidate.EnableAllowFocusChange;
             this.ClientSize = new System.Drawing.Size(543, 322);
             this.Controls.Add(this.SettingsMenu);
             this.Controls.Add(this.restoreWindowButton);

--- a/BorderlessMinecraft/Form1.Designer.cs
+++ b/BorderlessMinecraft/Form1.Designer.cs
@@ -276,6 +276,7 @@ namespace BorderlessMinecraft
             this.TrayIcon.ContextMenuStrip = this.ToolTipContextMenu;
             this.TrayIcon.Icon = ((System.Drawing.Icon)(resources.GetObject("TrayIcon.Icon")));
             this.TrayIcon.Text = "Borderless Minecraft";
+            this.TrayIcon.MouseClick += new System.Windows.Forms.MouseEventHandler(this.TrayIcon_Click);
             // 
             // ToolTipContextMenu
             // 
@@ -291,6 +292,7 @@ namespace BorderlessMinecraft
             this.Exit.Size = new System.Drawing.Size(116, 22);
             this.Exit.Text = "Exit";
             this.Exit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.Exit.Click += new System.EventHandler(this.Exit_Click);
             // 
             // ContextMenuSettings
             // 
@@ -331,6 +333,7 @@ namespace BorderlessMinecraft
             this.startOnBootMenuItem.Name = "startOnBootMenuItem";
             this.startOnBootMenuItem.Size = new System.Drawing.Size(187, 22);
             this.startOnBootMenuItem.Text = "Start on Boot";
+            this.startOnBootMenuItem.CheckedChanged += new System.EventHandler(this.StartOnBootItem_CheckedChanged);
             // 
             // startMinimizedMenuItem
             // 
@@ -338,6 +341,7 @@ namespace BorderlessMinecraft
             this.startMinimizedMenuItem.Name = "startMinimizedMenuItem";
             this.startMinimizedMenuItem.Size = new System.Drawing.Size(187, 22);
             this.startMinimizedMenuItem.Text = "Start Minimized";
+            this.startMinimizedMenuItem.CheckedChanged += new System.EventHandler(this.StartMinimizedItem_CheckedChanged);
             // 
             // minimizeToTrayMenuItem
             // 
@@ -345,6 +349,7 @@ namespace BorderlessMinecraft
             this.minimizeToTrayMenuItem.Name = "minimizeToTrayMenuItem";
             this.minimizeToTrayMenuItem.Size = new System.Drawing.Size(187, 22);
             this.minimizeToTrayMenuItem.Text = "Minimize to Tray";
+            this.minimizeToTrayMenuItem.CheckedChanged += new System.EventHandler(this.MinimizeToTrayItem_CheckedChanged);
             // 
             // automaticBorderlessMenuItem
             // 
@@ -353,6 +358,7 @@ namespace BorderlessMinecraft
             this.automaticBorderlessMenuItem.Size = new System.Drawing.Size(187, 22);
             this.automaticBorderlessMenuItem.Text = "Automatic Borderless";
             this.automaticBorderlessMenuItem.ToolTipText = "Requires administrator privleges";
+            this.automaticBorderlessMenuItem.CheckedChanged += new System.EventHandler(this.AutoBorderlessItem_CheckedChanged);
             // 
             // preserveTaskbarMenuItem
             // 
@@ -361,6 +367,7 @@ namespace BorderlessMinecraft
             this.preserveTaskbarMenuItem.Size = new System.Drawing.Size(187, 22);
             this.preserveTaskbarMenuItem.Text = "Preserve Taskbar";
             this.preserveTaskbarMenuItem.ToolTipText = "The taskbar will be visible below Minecraft";
+            this.preserveTaskbarMenuItem.CheckedChanged += new System.EventHandler(this.PreserveTaskBarItem_CheckedChanged);
             // 
             // showAllClientsMenuItem
             // 
@@ -369,6 +376,7 @@ namespace BorderlessMinecraft
             this.showAllClientsMenuItem.Size = new System.Drawing.Size(187, 22);
             this.showAllClientsMenuItem.Text = "Show All Clients";
             this.showAllClientsMenuItem.ToolTipText = "Shows non-vanilla MC clients, but may show other Java applications as well";
+            this.showAllClientsMenuItem.CheckedChanged += new System.EventHandler(this.ShowAllClientsItem_CheckedChanged);
             // 
             // MainForm
             // 
@@ -402,6 +410,7 @@ namespace BorderlessMinecraft
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "MainForm";
             this.Text = "Borderless Minecraft <version>";
+            this.Resize += new System.EventHandler(this.MainForm_Resize);
             ((System.ComponentModel.ISupportInitialize)(this.mainTitlePictureBox)).EndInit();
             this.ToolTipContextMenu.ResumeLayout(false);
             this.SettingsMenu.ResumeLayout(false);

--- a/BorderlessMinecraft/Form1.cs
+++ b/BorderlessMinecraft/Form1.cs
@@ -36,7 +36,7 @@ using static BorderlessMinecraft.DLLInterop; //includ the static DLL Interop cla
 
 namespace BorderlessMinecraft
 {
-    internal partial class Form1 : Form
+    internal partial class MainForm : Form
     {
         int? AutoBorderlessPID; //the process id of an automatically set borderless window
         Process[] minecraftProcesses; //initializes an array of processess
@@ -54,27 +54,27 @@ namespace BorderlessMinecraft
         //    }
         //}
 
-        internal Form1()
+        internal MainForm()
         {
             InitializeComponent();
             AddProcesses();
 
             //create the ToolTip for advanced mode hover
-            ToolTip toolTip1 = new ToolTip();
+            ToolTip advancedToolTip = new ToolTip();
 
-            toolTip1.AutoPopDelay = 5000;
-            toolTip1.InitialDelay = 1;
-            toolTip1.ReshowDelay = 500;
-            toolTip1.ShowAlways = true;
+            advancedToolTip.AutoPopDelay = 5000;
+            advancedToolTip.InitialDelay = 1;
+            advancedToolTip.ReshowDelay = 500;
+            advancedToolTip.ShowAlways = true;
 
-            toolTip1.SetToolTip(this.checkBox1, "Enables the use of custom positioning and sizing.");
+            advancedToolTip.SetToolTip(this.advancedCheckBox, "Enables the use of custom positioning and sizing.");
 
-            toolStripMenuItem1.Checked = Config.StartOnBoot;
-            toolStripMenuItem2.Checked = Config.StartMinimized;
-            toolStripMenuItem3.Checked = Config.MinimizeToTray;
-            toolStripMenuItem4.Checked = Config.AutomaticBorderless;
-            toolStripMenuItem5.Checked = Config.PreserveTaskBar;
-            toolStripMenuItem6.Checked = Config.ShowAllClients;
+            startOnBootMenuItem.Checked = Config.StartOnBoot;
+            startMinimizedMenuItem.Checked = Config.StartMinimized;
+            minimizeToTrayMenuItem.Checked = Config.MinimizeToTray;
+            automaticBorderlessMenuItem.Checked = Config.AutomaticBorderless;
+            preserveTaskbarMenuItem.Checked = Config.PreserveTaskBar;
+            showAllClientsMenuItem.Checked = Config.ShowAllClients;
 
             ProcessMonitor = new ProcessMonitor(); //create the process monitor
             ProcessMonitor.OnJavaAppStarted += ProcessMonitor_OnJavaAppStarted; //attach events
@@ -84,17 +84,17 @@ namespace BorderlessMinecraft
                 ProcessMonitor.Start(); //this call must occur after attaching the OnProcessShouldExit event
 
             //set up event handlers
-            Resize += Form1_Resize1;
+            Resize += MainForm_Resize1;
 
             TrayIcon.MouseClick += TrayIcon_Click;
             Exit.Click += Exit_Click;
 
-            toolStripMenuItem1.CheckedChanged += StartOnBootItem_CheckedChanged;
-            toolStripMenuItem2.CheckedChanged += StartMinimizedItem_CheckedChanged;
-            toolStripMenuItem3.CheckedChanged += MinimizeToTrayItem_CheckedChanged;
-            toolStripMenuItem4.CheckedChanged += AutoBorderlessItem_CheckedChanged;
-            toolStripMenuItem5.CheckedChanged += PreserveTaskBarItem_CheckedChanged;
-            toolStripMenuItem6.CheckedChanged += ShowAllClientsItem_CheckedChanged;
+            startOnBootMenuItem.CheckedChanged += StartOnBootItem_CheckedChanged;
+            startMinimizedMenuItem.CheckedChanged += StartMinimizedItem_CheckedChanged;
+            minimizeToTrayMenuItem.CheckedChanged += MinimizeToTrayItem_CheckedChanged;
+            automaticBorderlessMenuItem.CheckedChanged += AutoBorderlessItem_CheckedChanged;
+            preserveTaskbarMenuItem.CheckedChanged += PreserveTaskBarItem_CheckedChanged;
+            showAllClientsMenuItem.CheckedChanged += ShowAllClientsItem_CheckedChanged;
 
             if (Config.StartMinimized && IsAutoStarted()) //ensure the app has autostarted and minimize to tray is enabled. This ensures normal starts will not be minimized
             {
@@ -170,10 +170,10 @@ namespace BorderlessMinecraft
 
         private void AddProcesses() //method to add processes to list
         {
-            listBox1.Items.Clear(); //clear the listbox on refresh
-            button1.Enabled = false; //disable the button by default
-            button3.Enabled = false; //disable the button by default
-            button4.Enabled = false; //disable the button by default
+            processesListBox.Items.Clear(); //clear the listbox on refresh
+            goBorderlessButton.Enabled = false; //disable the button by default
+            setTitleButton.Enabled = false; //disable the button by default
+            restoreWindowButton.Enabled = false; //disable the button by default
 
             if (Config.ShowAllClients) //if the checkbox is checked, no title filtering will occur
             {
@@ -186,7 +186,7 @@ namespace BorderlessMinecraft
 
             foreach (Process proc in minecraftProcesses)
             {
-                listBox1.Items.Add(proc.MainWindowTitle); //adds process title to list
+                processesListBox.Items.Add(proc.MainWindowTitle); //adds process title to list
             }
         }
 
@@ -206,7 +206,7 @@ namespace BorderlessMinecraft
 
         }
 
-        private void button1_Click(object sender, EventArgs e) //go borderless button
+        private void goBorderlessButton_Click(object sender, EventArgs e) //go borderless button
         {
             //default values, changed by advanced mode
             int xPos = 0;
@@ -220,45 +220,45 @@ namespace BorderlessMinecraft
             }
 
             //advanced mode checks
-            if (textBox1.Text != "" && int.TryParse(textBox1.Text, out int parsed))
+            if (xPosTextBox.Text != "" && int.TryParse(xPosTextBox.Text, out int parsed))
                 xPos = parsed;
-            if (textBox2.Text != "" && int.TryParse(textBox2.Text, out int parsed2))
+            if (yPosTextBox.Text != "" && int.TryParse(yPosTextBox.Text, out int parsed2))
                 yPos = parsed2;
-            if (textBox3.Text != "" && int.TryParse(textBox3.Text, out int parsed3))
+            if (widthTextBox.Text != "" && int.TryParse(widthTextBox.Text, out int parsed3))
                 xRes = parsed3;
-            if (textBox4.Text != "" && int.TryParse(textBox4.Text, out int parsed4))
+            if (heightTextBox.Text != "" && int.TryParse(heightTextBox.Text, out int parsed4))
                 yRes = parsed4;
-            IntPtr handle = minecraftProcesses[listBox1.SelectedIndex].MainWindowHandle; //gets the minecraft process by index, and then its handle
-            int pid = minecraftProcesses[listBox1.SelectedIndex].Id; //get the minecraft process by id
+            IntPtr handle = minecraftProcesses[processesListBox.SelectedIndex].MainWindowHandle; //gets the minecraft process by index, and then its handle
+            int pid = minecraftProcesses[processesListBox.SelectedIndex].Id; //get the minecraft process by id
             GoBorderless(handle, xPos, yPos, xRes, yRes);
             if (!AutoBorderlessPID.HasValue) //save this pid to effectively disable auto borderless. Otherwise a second instance of MC would also go borderless
                 AutoBorderlessPID = pid;
         }
 
-        private void button2_Click(object sender, EventArgs e) //refresh button
+        private void refreshButton_Click(object sender, EventArgs e) //refresh button
         {
             AddProcesses();
         }
 
-        private void listBox1_SelectedIndexChanged_1(object sender, EventArgs e)
+        private void processesListBox_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (listBox1.SelectedIndex > -1) //checks if something is selected
+            if (processesListBox.SelectedIndex > -1) //checks if something is selected
             {
-                button1.Enabled = true; //enable the button when a session is seleced
-                button3.Enabled = true; //enable the button when a session is seleced
-                button4.Enabled = true; //enable the button when a session is seleced
+                goBorderlessButton.Enabled = true; //enable the button when a session is seleced
+                setTitleButton.Enabled = true; //enable the button when a session is seleced
+                restoreWindowButton.Enabled = true; //enable the button when a session is seleced
             }
         }
 
-        private void button3_Click(object sender, EventArgs e) //edit title button
+        private void setTitleButton_Click(object sender, EventArgs e) //edit title button
         {
-            IntPtr handle = minecraftProcesses[listBox1.SelectedIndex].MainWindowHandle; //gets the minecraft process by index, and then its handle
-            int PID = minecraftProcesses[listBox1.SelectedIndex].Id;
-            string currentTitle = minecraftProcesses[listBox1.SelectedIndex].MainWindowTitle; //gets the minecraft process by index, and then its title
+            IntPtr handle = minecraftProcesses[processesListBox.SelectedIndex].MainWindowHandle; //gets the minecraft process by index, and then its handle
+            int PID = minecraftProcesses[processesListBox.SelectedIndex].Id;
+            string currentTitle = minecraftProcesses[processesListBox.SelectedIndex].MainWindowTitle; //gets the minecraft process by index, and then its title
             string title;
-            if (textBox5.Text != "") //if the textbox has content, use for title
+            if (newTitleTextBox.Text != "") //if the textbox has content, use for title
             {
-                title = textBox5.Text;
+                title = newTitleTextBox.Text;
 
             }
             else //if the textbox is empty, use default
@@ -272,10 +272,10 @@ namespace BorderlessMinecraft
             }
 
             AddProcesses(); //after rename, refresh the list
-            textBox5.Text = ""; //reset text
+            newTitleTextBox.Text = ""; //reset text
         }
 
-        private void button4_Click(object sender, EventArgs e) //restore window button
+        private void restoreWindowButton_Click(object sender, EventArgs e) //restore window button
         {
             //default values, changed by advanced mode
             int xPos = GetCenterx();
@@ -283,44 +283,44 @@ namespace BorderlessMinecraft
             int xRes = xDefaultRes;
             int yRes = yDefaultRes;
 
-            if (textBox1.Text != "")
+            if (xPosTextBox.Text != "")
             {
                 try
                 {
-                    xPos = Convert.ToInt32(textBox1.Text); //if there is content in the textbox, an attempt is made to assign it to variable
+                    xPos = Convert.ToInt32(xPosTextBox.Text); //if there is content in the textbox, an attempt is made to assign it to variable
                 }
                 catch
                 {
                     xPos = GetCenterx();
                 }
             }
-            if (textBox2.Text != "")
+            if (yPosTextBox.Text != "")
             {
                 try
                 {
-                    yPos = Convert.ToInt32(textBox2.Text); //if there is content in the textbox, an attempt is made to assign it to variable
+                    yPos = Convert.ToInt32(yPosTextBox.Text); //if there is content in the textbox, an attempt is made to assign it to variable
                 }
                 catch
                 {
                     yPos = GetCentery();
                 }
             }
-            if (textBox3.Text != "")
+            if (widthTextBox.Text != "")
             {
                 try
                 {
-                    xRes = Convert.ToInt32(textBox3.Text); //if there is content in the textbox, an attempt is made to assign it to variable
+                    xRes = Convert.ToInt32(widthTextBox.Text); //if there is content in the textbox, an attempt is made to assign it to variable
                 }
                 catch
                 {
                     xRes = xDefaultRes;
                 }
             }
-            if (textBox4.Text != "")
+            if (heightTextBox.Text != "")
             {
                 try
                 {
-                    yRes = Convert.ToInt32(textBox4.Text); //if there is content in the textbox, an attempt is made to assign it to variable
+                    yRes = Convert.ToInt32(heightTextBox.Text); //if there is content in the textbox, an attempt is made to assign it to variable
                 }
                 catch
                 {
@@ -328,8 +328,8 @@ namespace BorderlessMinecraft
                 }
             }
 
-            IntPtr handle = minecraftProcesses[listBox1.SelectedIndex].MainWindowHandle; //gets the minecraft process by index, and then its handle
-            int pid = minecraftProcesses[listBox1.SelectedIndex].Id; //get the pid
+            IntPtr handle = minecraftProcesses[processesListBox.SelectedIndex].MainWindowHandle; //gets the minecraft process by index, and then its handle
+            int pid = minecraftProcesses[processesListBox.SelectedIndex].Id; //get the pid
             RestoreWindow(handle);
             UndoBorderless(handle);
             SetPos(handle, xPos, yPos, xRes, yRes);
@@ -338,37 +338,37 @@ namespace BorderlessMinecraft
                 AutoBorderlessPID = null;
         }
 
-        private void checkBox1_CheckedChanged(object sender, EventArgs e)
+        private void advancedCheckBox_CheckedChanged(object sender, EventArgs e)
         {
-            if (checkBox1.Checked) //if advanced mode is on, make visible
+            if (advancedCheckBox.Checked) //if advanced mode is on, make visible
             {
-                textBox1.Visible = true;
-                textBox2.Visible = true;
-                textBox3.Visible = true;
-                textBox4.Visible = true;
-                label1.Visible = true;
-                label2.Visible = true;
-                label3.Visible = true;
-                label4.Visible = true;
+                xPosTextBox.Visible = true;
+                yPosTextBox.Visible = true;
+                widthTextBox.Visible = true;
+                heightTextBox.Visible = true;
+                xPosLabel.Visible = true;
+                yPosLabel.Visible = true;
+                widthLabel.Visible = true;
+                heightLabel.Visible = true;
             }
             else
             {
-                textBox1.Text = "";
-                textBox2.Text = "";
-                textBox3.Text = "";
-                textBox4.Text = "";
-                textBox1.Visible = false;
-                textBox2.Visible = false;
-                textBox3.Visible = false;
-                textBox4.Visible = false;
-                label1.Visible = false;
-                label2.Visible = false;
-                label3.Visible = false;
-                label4.Visible = false;
+                xPosTextBox.Text = "";
+                yPosTextBox.Text = "";
+                widthTextBox.Text = "";
+                heightTextBox.Text = "";
+                xPosTextBox.Visible = false;
+                yPosTextBox.Visible = false;
+                widthTextBox.Visible = false;
+                heightTextBox.Visible = false;
+                xPosLabel.Visible = false;
+                yPosLabel.Visible = false;
+                widthLabel.Visible = false;
+                heightLabel.Visible = false;
             }
         }
 
-        private void label1_Click(object sender, EventArgs e)
+        private void xPosLabel_Click(object sender, EventArgs e)
         {
 
         }
@@ -378,7 +378,7 @@ namespace BorderlessMinecraft
             AddProcesses(); //refresh the process list when changing the filter option
         }
 
-        private void Form1_Resize1(object sender, EventArgs e)
+        private void MainForm_Resize1(object sender, EventArgs e)
         {
             //if the form is minimized  
             //hide it from the task bar  

--- a/BorderlessMinecraft/Form1.cs
+++ b/BorderlessMinecraft/Form1.cs
@@ -147,7 +147,11 @@ namespace BorderlessMinecraft
                 ProcessMonitor.Stop();
         }
         private void PreserveTaskBarItem_CheckedChanged(object sender, EventArgs e) => Config.PreserveTaskBar = ((ToolStripMenuItem)sender).Checked;
-        private void ShowAllClientsItem_CheckedChanged(object sender, EventArgs e) => Config.ShowAllClients = ((ToolStripMenuItem)sender).Checked;
+        private void ShowAllClientsItem_CheckedChanged(object sender, EventArgs e)
+        {
+            Config.ShowAllClients = ((ToolStripMenuItem)sender).Checked;
+            AddProcesses();
+        }
 
         private void Exit_Click(object sender, EventArgs e) => Close();
         private void ContextMenuShow_Click(object sender, EventArgs e) => ShowWindow();
@@ -364,11 +368,6 @@ namespace BorderlessMinecraft
             };
             string joinedAdvancedParams = string.Join(",", advancedParams);
             Config.AdvancedParams = joinedAdvancedParams;
-        }
-
-        private void checkBox3_CheckedChanged(object sender, EventArgs e)
-        {
-            AddProcesses(); //refresh the process list when changing the filter option
         }
 
         private void MainForm_Resize(object sender, EventArgs e)

--- a/BorderlessMinecraft/Form1.cs
+++ b/BorderlessMinecraft/Form1.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using BorderlessMinecraft.Configuration;
@@ -41,6 +42,8 @@ namespace BorderlessMinecraft
         {
             InitializeComponent();
             AddProcesses();
+
+            this.Text = GetFormTitle();
 
             //create the ToolTip for advanced mode hover
             ToolTip advancedToolTip = new ToolTip();
@@ -95,6 +98,13 @@ namespace BorderlessMinecraft
                 ShowInTaskbar = false; //When hiding on startup, we need to explicitly set ShowInTaskbar to false
                 TrayIcon.Visible = true;
             }
+        }
+
+        private string GetFormTitle()
+        {
+            AssemblyName assemblyName = Assembly.GetEntryAssembly().GetName();
+            Version version = assemblyName.Version;
+            return $"Borderless Minecraft {version.Major}.{version.Minor}.{version.Build}";
         }
 
         private void ProcessMonitor_OnProcessShouldExit() => Environment.Exit(0);
@@ -344,7 +354,6 @@ namespace BorderlessMinecraft
 
         private void AdvancedParamsTextBox_Validating(object sender, CancelEventArgs e)
         {
-
             TextBox textBox = (TextBox)sender;
             if (!int.TryParse(textBox.Text, out _))
             {

--- a/BorderlessMinecraft/Form1.cs
+++ b/BorderlessMinecraft/Form1.cs
@@ -55,10 +55,15 @@ namespace BorderlessMinecraft
 
             advancedToolTip.SetToolTip(this.advancedCheckBox, "Enables the use of custom positioning and sizing.");
 
+            ProcessMonitor = new ProcessMonitor(); //create the process monitor, must happen before settings are loaded
+            ProcessMonitor.OnJavaAppStarted += ProcessMonitor_OnJavaAppStarted; //attach events
+            ProcessMonitor.OnJavaAppStopped += ProcessMonitor_OnJavaAppStopped;
+            ProcessMonitor.OnProcessShouldExit += ProcessMonitor_OnProcessShouldExit;
+
             startOnBootMenuItem.Checked = Config.StartOnBoot;
             startMinimizedMenuItem.Checked = Config.StartMinimized;
             minimizeToTrayMenuItem.Checked = Config.MinimizeToTray;
-            automaticBorderlessMenuItem.Checked = Config.AutomaticBorderless;
+            automaticBorderlessMenuItem.Checked = Config.AutomaticBorderless; //starts the ProcessMonitor if set to true
             preserveTaskbarMenuItem.Checked = Config.PreserveTaskBar;
             showAllClientsMenuItem.Checked = Config.ShowAllClients;
             advancedCheckBox.Checked = Config.Advanced;
@@ -70,26 +75,6 @@ namespace BorderlessMinecraft
                 widthTextBox.Text = advancedParams[2];
                 heightTextBox.Text = advancedParams[3];
             }
-
-            ProcessMonitor = new ProcessMonitor(); //create the process monitor
-            ProcessMonitor.OnJavaAppStarted += ProcessMonitor_OnJavaAppStarted; //attach events
-            ProcessMonitor.OnJavaAppStopped += ProcessMonitor_OnJavaAppStopped;
-            ProcessMonitor.OnProcessShouldExit += ProcessMonitor_OnProcessShouldExit;
-            if (Config.AutomaticBorderless) //start listening if auto borderless is enabled
-                ProcessMonitor.Start(); //this call must occur after attaching the OnProcessShouldExit event
-
-            //set up event handlers
-            Resize += MainForm_Resize1;
-
-            TrayIcon.MouseClick += TrayIcon_Click;
-            Exit.Click += Exit_Click;
-
-            startOnBootMenuItem.CheckedChanged += StartOnBootItem_CheckedChanged;
-            startMinimizedMenuItem.CheckedChanged += StartMinimizedItem_CheckedChanged;
-            minimizeToTrayMenuItem.CheckedChanged += MinimizeToTrayItem_CheckedChanged;
-            automaticBorderlessMenuItem.CheckedChanged += AutoBorderlessItem_CheckedChanged;
-            preserveTaskbarMenuItem.CheckedChanged += PreserveTaskBarItem_CheckedChanged;
-            showAllClientsMenuItem.CheckedChanged += ShowAllClientsItem_CheckedChanged;
 
             if (Config.StartMinimized && IsAutoStarted()) //ensure the app has autostarted and minimize to tray is enabled. This ensures normal starts will not be minimized
             {
@@ -383,7 +368,7 @@ namespace BorderlessMinecraft
             AddProcesses(); //refresh the process list when changing the filter option
         }
 
-        private void MainForm_Resize1(object sender, EventArgs e)
+        private void MainForm_Resize(object sender, EventArgs e)
         {
             //if the form is minimized  
             //hide it from the task bar  

--- a/BorderlessMinecraft/Form1.cs
+++ b/BorderlessMinecraft/Form1.cs
@@ -114,7 +114,7 @@ namespace BorderlessMinecraft
                 }
 
                 if (process.MainWindowTitle.Contains("Minecraft")) //for now just check the title with a magic string. In the future this will allow better control. Also note that we have already filtered out any non-java process
-                    GoBorderless(handle, 0, 0, GetScreenRezx(), GetScreenRezy()); //go borderless
+                    TriggerBorderless(handle); //go borderless
             }
             AddProcessesThreadSafe();
         }
@@ -197,6 +197,14 @@ namespace BorderlessMinecraft
 
         private void goBorderlessButton_Click(object sender, EventArgs e) //go borderless button
         {
+            IntPtr handle = minecraftProcesses[processesListBox.SelectedIndex].MainWindowHandle; //gets the minecraft process by index, and then its handle
+            TriggerBorderless(handle);
+            int pid = minecraftProcesses[processesListBox.SelectedIndex].Id; //get the minecraft process by id
+            if (!AutoBorderlessPID.HasValue) //save this pid to effectively disable auto borderless. Otherwise a second instance of MC would also go borderless
+                AutoBorderlessPID = pid;
+        }
+
+        private void TriggerBorderless(IntPtr handle) {
             //default values, changed by advanced mode
             int xPos = 0;
             int yPos = 0;
@@ -220,11 +228,7 @@ namespace BorderlessMinecraft
                 if (int.TryParse(heightTextBox.Text, out int parsed4))
                     yRes = parsed4;
             }
-            IntPtr handle = minecraftProcesses[processesListBox.SelectedIndex].MainWindowHandle; //gets the minecraft process by index, and then its handle
-            int pid = minecraftProcesses[processesListBox.SelectedIndex].Id; //get the minecraft process by id
             GoBorderless(handle, xPos, yPos, xRes, yRes);
-            if (!AutoBorderlessPID.HasValue) //save this pid to effectively disable auto borderless. Otherwise a second instance of MC would also go borderless
-                AutoBorderlessPID = pid;
         }
 
         private void refreshButton_Click(object sender, EventArgs e) //refresh button

--- a/BorderlessMinecraft/Form1.cs
+++ b/BorderlessMinecraft/Form1.cs
@@ -131,11 +131,7 @@ namespace BorderlessMinecraft
         private void TrayIcon_Click(object sender, MouseEventArgs e)
         {
             if (e.Button == MouseButtons.Left) //show the window when the tray icon is left clicked
-            {
-                Show();
-                WindowState = FormWindowState.Normal;
-                ShowInTaskbar = true;
-            }
+                ShowWindow();
         }
 
         private void StartOnBootItem_CheckedChanged(object sender, EventArgs e) => Config.StartOnBoot = ((ToolStripMenuItem)sender).Checked;
@@ -154,6 +150,13 @@ namespace BorderlessMinecraft
         private void ShowAllClientsItem_CheckedChanged(object sender, EventArgs e) => Config.ShowAllClients = ((ToolStripMenuItem)sender).Checked;
 
         private void Exit_Click(object sender, EventArgs e) => Close();
+        private void ContextMenuShow_Click(object sender, EventArgs e) => ShowWindow();
+        private void ShowWindow()
+        {
+            Show();
+            WindowState = FormWindowState.Normal;
+            ShowInTaskbar = true;
+        }
 
         private void AddProcesses() //method to add processes to list
         {

--- a/BorderlessMinecraft/Form1.resx
+++ b/BorderlessMinecraft/Form1.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="pictureBox1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="mainTitlePictureBox.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAfAAAAAnCAYAAADw4BrFAAAABGdBTUEAALGPC/xhBQAATNtJREFUeF7t
         nQmUXkW1769kTgjkMkMGZExCQgxwQUFAJsP8ZLiiqEtE0Yu6UBkE5TGJjA9BEQRZkIQpw8vU6c7QK52k

--- a/BorderlessMinecraft/Program.cs
+++ b/BorderlessMinecraft/Program.cs
@@ -36,7 +36,7 @@ namespace BorderlessMinecraft
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new Form1());
+            Application.Run(new MainForm());
         }
     }
 }

--- a/BorderlessMinecraft/Properties/AssemblyInfo.cs
+++ b/BorderlessMinecraft/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.3.1.*")]
 [assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
Summary of changes:
- Form elements now have a proper name e.g. `goBorderlessButton` instead of `button1`
- Advanced check-box state and x/y position/size textboxes are stored in registry like other settings
- When borderless is triggered automatically, it will use parameters from advanced settings
- Replaced unused "Settings" button from tray context menu with "Show Borderless Minecraft" that re-opens the app window
- Refreshing the list when "Show all clients" is changed
- Moving event handlers assignment for settings to the Designer.cs, same as already used for buttons