### PR TITLE
Added indicators for processes not being found

### DIFF
--- a/BorderlessMinecraft/Form1.cs
+++ b/BorderlessMinecraft/Form1.cs
@@ -164,6 +164,7 @@ namespace BorderlessMinecraft
 
         private void AddProcesses() //method to add processes to list
         {
+            processesListBox.Enabled = true; //enables the listbox
             processesListBox.Items.Clear(); //clear the listbox on refresh
             goBorderlessButton.Enabled = false; //disable the button by default
             setTitleButton.Enabled = false; //disable the button by default
@@ -178,6 +179,15 @@ namespace BorderlessMinecraft
                 minecraftProcesses = GetProcesses(renamedProcesses, "Minecraft");
             }
 
+            if (minecraftProcesses.Length == 0) // If no processes are found
+            {
+                processesListBox.Enabled = false; // Disable the ListBox so it cannot be selected
+                processesListBox.Items.Add("Found no processes");
+                if (Config.ShowAllClients) { return; } // Return if Show All Clients is enabled
+                processesListBox.Items.Add("Tip: You can turn on all clients by going to"); 
+                processesListBox.Items.Add("Settings > Show All Clients"); 
+                return; //Returns as rest of the code is not needed to be ran
+            }
             foreach (Process proc in minecraftProcesses)
             {
                 processesListBox.Items.Add(proc.MainWindowTitle); //adds process title to list


### PR DESCRIPTION
## What I did
Added an indicator for when processes haven't been found and notifies the user that they can show all clients if they are not doing so already
## Proof of working
![x7NZm1c6iY](https://user-images.githubusercontent.com/60571306/149817837-3c07695e-dad3-4040-8c51-9a11a3a36ddf.gif)
## For author to do
 - Update the version to what you find appropriate
## Additional info
I had issues related to signing certificate in the certificate store when I tried running it with the debugger. I deleted:
```cs
<PropertyGroup>
  <ManifestCertificateThumbprint>F0BB6B4AB81DCB530A46721FAE58938516286746</ManifestCertificateThumbprint>
</PropertyGroup>
<PropertyGroup>
    <ManifestKeyFile>BorderlessMinecraft_TemporaryKey.pfx</ManifestKeyFile>
</PropertyGroup>
<PropertyGroup>
    <GenerateManifests>true</GenerateManifests>
</PropertyGroup>
<PropertyGroup>
    <SignManifests>true</SignManifests>
</PropertyGroup>
  ```
  However, I left it out of this pull request as I believe the error occurred at the fault of myself.