### PR TITLE
Merge changes for version 1.3.4

### DIFF
--- a/BorderlessMinecraft/Processes/ProcessMonitor.cs
+++ b/BorderlessMinecraft/Processes/ProcessMonitor.cs
@@ -59,7 +59,7 @@ namespace BorderlessMinecraft.Processes
         private void StartEventWatcher_EventArrived(object sender, EventArrivedEventArgs e)
         {
             string processName = e.NewEvent.Properties["ProcessName"].Value.ToString();
-            if (processName.Contains("javaw.exe")) //true if the process name is java
+            if (processName.Contains("javaw.exe") || processName.Contains("java.exe")) //true if the process name is java
             {
                 OnJavaAppStarted.Invoke(Convert.ToInt32(e.NewEvent.Properties["ProcessID"].Value)); //return the process id
             }
@@ -68,7 +68,7 @@ namespace BorderlessMinecraft.Processes
         private void StopEventWatcher_EventArrived(object sender, EventArrivedEventArgs e)
         {
             string processName = e.NewEvent.Properties["ProcessName"].Value.ToString();
-            if (processName.Contains("javaw.exe")) //true if the process name is java
+            if (processName.Contains("javaw.exe") || processName.Contains("java.exe")) //true if the process name is java
             {
                 OnJavaAppStopped.Invoke(Convert.ToInt32(e.NewEvent.Properties["ProcessID"].Value)); //return the process id
             }

--- a/BorderlessMinecraft/Properties/AssemblyInfo.cs
+++ b/BorderlessMinecraft/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.3.*")]
-[assembly: AssemblyFileVersion("1.3.3.0")]
+[assembly: AssemblyVersion("1.3.4.*")]
+[assembly: AssemblyFileVersion("1.3.4.0")]


### PR DESCRIPTION
Fixes an issue where Minecraft instances launched under "java.exe" instead of "javaw.exe" would not be detected.